### PR TITLE
Remove unique constraint on googleId to resolve registration conflicts

### DIFF
--- a/server/graphql/schema/User.ts
+++ b/server/graphql/schema/User.ts
@@ -35,7 +35,7 @@ export const UserTypeDef = `#graphql
         deposit(amount: Float!): balanceResponse!
         withdraw(amount: Float!): balanceResponse!
         changeUsername(newUsername: String!, confirmPassword: String!): usernameChangeResponse!
-        googleLogin(googleToken: String!): UserResponse!
+        googleLogin(googleToken: String!): UserResponse
         sendOtp(username: String!): String
         verifyOtp(username: String!, otp: String!): String
         resetPassword(username: String!, password: String!, confirmPassword: String!): String

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -18,13 +18,6 @@ const UserSchema = new Schema({
         type: Date,
         default: Date.now,
     },
-    isVerified: {
-        type: Boolean,
-        default: false,
-    },
-    verificationToken: {
-        type: String,
-    },
     balance: {
         type: Number,
         default: 500,
@@ -32,10 +25,16 @@ const UserSchema = new Schema({
     },
     googleId: {
         type: String,
-        default: false,
+        sparse: true,  // This will allow `null` values for `googleId`
     },
-    otp: { type: String, required: false },
-    otpExpiry: { type: Date, required: false }
+    otp: { 
+        type: String, 
+        required: false 
+    },
+    otpExpiry: { 
+        type: Date, 
+        required: false 
+    }
 });
 
 // Export the Mongoose model for the User schema


### PR DESCRIPTION
```
->Removed unique index on googleId to allow registration for users without Google accounts.
->Updated GraphQL schema to support nullable googleId, aligning it with backend changes.
```
```
In MongoDB shell or your database GUI, drop the unique index: 
db.users.dropIndex("googleId_1"); 

Add a new, sparse index:
db.users.createIndex({ googleId: 1 }, { sparse: true }); 
```

Issue:

![Selection_576](https://github.com/user-attachments/assets/2ff6111a-d0da-46c7-abd0-34fe656f4c78)


